### PR TITLE
Add CI for 32b and 64b ARM platforms (as well as x86_64)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,30 +1,54 @@
-name: Test Build Matrix
-
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  build_job:
+    # The host should always be linux
+    runs-on: ubuntu-20.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
+        include:
+          - arch: armv6
+            distro: buster
+          - arch: armv7
+            distro: buster
+          - arch: aarch64
+            distro: ubuntu20.04
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      shell: bash
-      run: |
-        # Install longmynd dependencies
-        sudo apt-get install libusb-1.0-0-dev libasound2-dev -y
-        # Install test matrix dependencies
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get update -q
-        sudo apt-get install gcc-7 gcc-8 gcc-9 gcc-10 -y
+      - uses: actions/checkout@v2.1.0
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Build Matrix
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
 
-    - name: Build longmynd
-      shell: bash
-      run: |
-        make clean && make werror GCC=gcc-7
-        make clean && make werror GCC=gcc-8
-        make clean && make werror GCC=gcc-9
-        make clean && make werror GCC=gcc-10
+          githubToken: ${{ github.token }}
+
+          shell: /bin/sh
+
+          install: |
+            case "${{ matrix.distro }}" in
+              buster)
+                apt-get update -q -y
+                apt-get install -q -y make gcc-7 gcc-8 libusb-1.0-0-dev libasound2-dev
+                ;;
+              ubuntu20.04)
+                apt-get update -q -y
+                apt-get install -q -y make gcc-9 gcc-10 libusb-1.0-0-dev libasound2-dev
+                ;;
+            esac
+
+          run: |
+            case "${{ matrix.distro }}" in
+              buster)
+                make clean && make werror CC=gcc-7
+                make clean && make werror CC=gcc-8
+                ;;
+              ubuntu20.04)
+                make clean && make werror CC=gcc-9
+                make clean && make werror CC=gcc-10
+                ;;
+            esac

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -16,7 +16,7 @@ jobs:
         # Install longmynd dependencies
         sudo apt-get install -q -y libusb-1.0-0-dev libasound2-dev
         # Install test matrix dependencies
-        sudo add-apt-repository -q -y ppa:ubuntu-toolchain-r/test
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         sudo apt-get update -q -y
         sudo apt-get install -q -y build-essential gcc-7 gcc-8 gcc-9 gcc-10
     - name: Build longmynd

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -33,11 +33,11 @@ jobs:
             case "${{ matrix.distro }}" in
               buster)
                 apt-get update -q -y
-                apt-get install -q -y make gcc-7 gcc-8 libusb-1.0-0-dev libasound2-dev
+                apt-get install -q -y build-essential gcc-7 gcc-8 libusb-1.0-0-dev libasound2-dev
                 ;;
               ubuntu20.04)
                 apt-get update -q -y
-                apt-get install -q -y make gcc-9 gcc-10 libusb-1.0-0-dev libasound2-dev
+                apt-get install -q -y build-essential gcc-9 gcc-10 libusb-1.0-0-dev libasound2-dev
                 ;;
             esac
 

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,7 +1,33 @@
 on: [push, pull_request]
 
 jobs:
-  build_job:
+  build-x86_64:
+    runs-on: ${{ matrix.os }}
+    name: Build on ${{ matrix.os }} x86_64
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04]
+
+    steps:
+    - uses: actions/checkout@v2.1.0
+    - name: Install dependencies
+      shell: bash
+      run: |
+        # Install longmynd dependencies
+        sudo apt-get install -q -y libusb-1.0-0-dev libasound2-dev
+        # Install test matrix dependencies
+        sudo add-apt-repository -q -y ppa:ubuntu-toolchain-r/test
+        sudo apt-get update -q -y
+        sudo apt-get install -q -y build-essential gcc-7 gcc-8 gcc-9 gcc-10
+    - name: Build longmynd
+      shell: bash
+      run: |
+        make clean && make werror CC=gcc-7
+        make clean && make werror CC=gcc-8
+        make clean && make werror CC=gcc-9
+        make clean && make werror CC=gcc-10
+
+  build-arm:
     # The host should always be linux
     runs-on: ubuntu-20.04
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }}

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ ifndef CC
 CC = gcc
 endif
 
-$(info Compiling longmynd with GCC $(shell $(CC) -dumpfullversion) on $(shell $(CC) -dumpmachine))
-
 # Build parallel
 MAKEFLAGS += -j$(shell nproc || printf 1)
 
@@ -30,7 +28,7 @@ COPT += -funsafe-math-optimizations
 CFLAGS += -Wall -Wextra -Wpedantic -Wunused -DVERSION=\"${VER}\" -pthread -D_GNU_SOURCE
 LDFLAGS += -lusb-1.0 -lm -lasound
 
-all: ${BIN} fake_read
+all: _print_banner ${BIN} fake_read
 
 debug: COPT = -Og
 debug: CFLAGS += -ggdb -fno-omit-frame-pointer
@@ -38,6 +36,9 @@ debug: all
 
 werror: CFLAGS += -Werror
 werror: all
+
+_print_banner:
+	@echo "Compiling longmynd with GCC $(shell $(CC) -dumpfullversion) on $(shell $(CC) -dumpmachine)"
 
 fake_read:
 	@echo "  CC     "$@

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ ifndef CC
 CC = gcc
 endif
 
+$(info Compiling longmynd with GCC $(shell $(CC) -dumpfullversion) on $(shell $(CC) -dumpmachine))
+
 # Build parallel
 MAKEFLAGS += -j$(shell nproc || printf 1)
 

--- a/ftdi_usb.c
+++ b/ftdi_usb.c
@@ -265,7 +265,7 @@ static uint8_t ftdi_usb_init(libusb_context **usb_context_ptr, libusb_device_han
 
     /* turn on debug */
     #if LIBUSB_API_VERSION >= 0x01000106
-    libusb_set_option(*usb_context_ptr, LIBUSB_LOG_LEVEL_INFO);
+    libusb_set_option(*usb_context_ptr, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
     #else
     libusb_set_debug(*usb_context_ptr, LIBUSB_LOG_LEVEL_INFO);
     #endif


### PR DESCRIPTION
An example failure catch can be seen here: https://github.com/BritishAmateurTelevisionClub/longmynd/runs/1190029779

Also features a fix for a misused libusb function found in the process.